### PR TITLE
Fix `y_test` to select 1st column when .values is used

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -10,7 +10,7 @@ model = pickle.load(open("models/model.pkl", "rb"))
 
 # Load the test data
 X_test = pd.read_csv("data/test_features.csv")
-y_test = pd.read_csv("data/test_y.csv").values
+y_test = pd.read_csv("data/test_y.csv").iloc[:, 0].values
 
 # Test on the model
 y_hat = model.predict(X_test)
@@ -31,7 +31,7 @@ title_fs=16
 
 ax = sns.scatterplot(x="true", y="pred",data=res_df)
 ax.set_aspect('equal')
-ax.set_xlabel('True y',fontsize = axis_fs) 
+ax.set_xlabel('True y',fontsize = axis_fs)
 ax.set_ylabel('Predicted y', fontsize = axis_fs)
 ax.set_title('Residuals', fontsize = title_fs)
 
@@ -41,4 +41,4 @@ plt.ylim((-1000,1000))
 plt.xlim((-1000,1000))
 
 plt.tight_layout()
-plt.savefig("residuals.png",dpi=120) 
+plt.savefig("residuals.png",dpi=120)


### PR DESCRIPTION
Fix `y_test` to select 1st column when .values is used is used to ensure seaborn can use the values

**Current issue:**
When using `y_test = pd.read_csv("data/test_y.csv").values`, the variable gets values in form of list of lists 
E.g. `[[val1],[val2],...[val100]]`,
The values that `seaborn` is expecting is in format of a single list .E.g. `[val1,val2....val100]`.
Error being thrown is : 
`TypeError: unhashable type: 'numpy.ndarray'`

**Fix for issue:**
Apply a column selector on the pandas DataFrame to select 1st column of `y_test` before the `.values` attribute is used.

